### PR TITLE
Add prop custom element to leader-line.

### DIFF
--- a/src/leader-line.js
+++ b/src/leader-line.js
@@ -1109,10 +1109,9 @@
     } else if (!props.isShown) {
       svg.style.visibility = 'hidden';
     }
-
-    var elementFromParent = props.options.customElement;
-
-    if(elementFromParent !== null) { 
+    
+    if(props.options.customElement.length > 0) { 
+      var elementFromParent = document.getElementById(props.options.customElement);
       elementFromParent.appendChild(svg)
     } else {
       baseDocument.body.appendChild(svg);
@@ -2506,7 +2505,6 @@
       plugOutlineColorSE      startPlugOutlineColor, endPlugOutlineColor
       plugOutlineSizeSE       startPlugOutlineSize, endPlugOutlineSize
       labelSEM                startLabel, endLabel, middleLabelanchorSE 
-      'customElement'         string
     */
     var options = props.options,
       newWindow, needsWindow, needs = {};
@@ -2686,17 +2684,6 @@
         function(value) { return value >= 1; }) || needs.plugOutline;
     });
 
-    // CustomElement (HTMLElement)
-    needs.custom = setValidType(
-      options,              // target object where we store
-      newOptions,           // input options
-      'customElement',      // property name in newOptions
-      'string',             // expected JS type
-      null,                 // internal option name (null means same as propName)
-      null,                 // index (not needed)
-      null,                 // default value (no default)
-    function(value) { return value instanceof HTMLElement; } // extra validation
-    ) || needs.custom;
 
     // label
     ['startLabel', 'endLabel', 'middleLabel'].forEach(function(optionName, i) {
@@ -3368,10 +3355,14 @@
    * @param {Object} [options] - Initial options.
    */
   function LeaderLine(start, end, customElement, options) {
+let leaderLineParentDivId  = '';
+    if(customElement !== undefined) {
+      leaderLineParentDivId = customElement;
+    }
     var props = {
       // Initialize properties as array.
       options: {anchorSE: [], socketSE: [], socketGravitySE: [], plugSE: [], plugColorSE: [], plugSizeSE: [],
-        plugOutlineEnabledSE: [], plugOutlineColorSE: [], plugOutlineSizeSE: [], labelSEM: ['', '', ''], customElement: null},
+        plugOutlineEnabledSE: [], plugOutlineColorSE: [], plugOutlineSizeSE: [], labelSEM: ['', '', ''], customElement: leaderLineParentDivId},
       optionIsAttach: {anchorSE: [false, false], labelSEM: [false, false, false]},
       curStats: {}, aplStats: {}, attachments: [], events: {}, reflowTargets: []
     };
@@ -3404,10 +3395,6 @@
       if (end) { options.end = end; }
     }
 
-    if(customElement !== null) {
-      options = copyTree(options);
-      options.customElement = customElement;
-    }
     props.isShown = props.aplStats.show_on = !options.hide; // isShown is applied in setOptions -> bindWindow
     this.setOptions(options);
 


### PR DESCRIPTION
This pull request introduces support for a new `customElement` option in the `LeaderLine` library, allowing users to specify a custom HTML element to append the SVG element instead of defaulting to the document body. The changes include updates to the constructor, options validation, and logic for handling the new property.



*** Able to send an extra HTMLElement to create leader-line svgs inside it.

```
var line1 = new LeaderLine(
    document.getElementById("terminal-1"),
    document.getElementById("terminal-2"),
    document.getElementById("wrapperr")
  )
```

### Support for `customElement` option:

* **Constructor update**: Modified the `LeaderLine` constructor to accept a `customElement` parameter and initialize it in the `options` object. Added logic to copy and assign the `customElement` if provided. (`[[1]](diffhunk://#diff-e44b08a94b5bb9f377ccb2d803ae0e1d11a1eb743820e487d1a61d669d0bcc1cL3352-R3374)`, `[[2]](diffhunk://#diff-e44b08a94b5bb9f377ccb2d803ae0e1d11a1eb743820e487d1a61d669d0bcc1cR3406-R3413)`)
* **Options validation**: Added validation logic for the `customElement` property to ensure it is an instance of `HTMLElement`. (`[src/leader-line.jsR2689-R2700](diffhunk://#diff-e44b08a94b5bb9f377ccb2d803ae0e1d11a1eb743820e487d1a61d669d0bcc1cR2689-R2700)`)
* **SVG appending logic**: Updated the logic to append the SVG element to the specified `customElement` if provided, or fallback to appending it to the document body. (`[src/leader-line.jsR1113-L1115](diffhunk://#diff-e44b08a94b5bb9f377ccb2d803ae0e1d11a1eb743820e487d1a61d669d0bcc1cR1113-L1115)`)
* **Options structure**: Extended the `options` object structure to include the new `customElement` property. (`[src/leader-line.jsL2503-R2509](diffhunk://#diff-e44b08a94b5bb9f377ccb2d803ae0e1d11a1eb743820e487d1a61d669d0bcc1cL2503-R2509)`)